### PR TITLE
Realização do exercício 22 de git

### DIFF
--- a/solucoes/01_git/16.md
+++ b/solucoes/01_git/16.md
@@ -1,0 +1,31 @@
+## Problema
+
+16 - Qual a diferença entre um _merge fast forward_ e um _merge commit_? 
+Em qual destes _merges_ é possível haver um _merge conflict_?
+
+## Soluções
+
+### Solução 1
+
+Um _merge fast forward_, apenas aplica as alterações feitas num _commit_
+(avanço rápido), que por exemplo, define um novo _branch_ criado 
+para corrigir uns erros encontrados. Após aplicar, atualiza o _branch master_ 
+para o último _commit_ feito no novo _branch_. 
+
+Executamos os seguintes comandos para atualizar o _branch master_ para o
+ _commit_ mais recente:
+
+```cs
+$ git checkout master
+$ git merge <nome_do_novo_branch>
+```
+
+Um _merge commit_ compara os dois _branches_ mais o _commit_ 
+antigo comum dos dois _branches_. Se não houver nenhum conflito aplica as 
+mudanças dos dois _branches_ em um novo _commit_.
+
+Este último _merge_ poderá ter um _merge conflict_, ou seja, alterações na 
+mesma linha em diferentes _branches_. Se for o caso, teria que se resolver o 
+conflito primeiro e depois executar o _commit_.
+
+*Por [Daniela Gameiro](https://github.com/DanielaGameiro)*

--- a/solucoes/01_git/22.md
+++ b/solucoes/01_git/22.md
@@ -21,8 +21,10 @@ Explica qual é o problema e como o podes resolver.
 
 ### Solução 1
 
-O problema é que existe um _merge conflit_ entre o _branch_ 'origin' e o _branch_ 'master', ou seja, existem alterações na mesma linha nos diferentes _branches_.
+O problema é que existe um _merge conflit_ entre o _branch_ `origin` e o _branch_ 
+`master`, ou seja, existem alterações na mesma linha nos diferentes _branches_.
 
-Para solucionar este problema é necessário resolver primeiro o conflito e só depois executar o _commit_.
+Para solucionar este problema é necessário resolver primeiro o conflito e só
+depois executar o _commit_.
 
 *Por [Daniela Gameiro](https://github.com/DanielaGameiro)*

--- a/solucoes/01_git/22.md
+++ b/solucoes/01_git/22.md
@@ -1,0 +1,28 @@
+## Problema
+
+22 - Estás a trabalhar no ramo local `master`, e tens alguns _commits_ feitos
+desde a última vez que sincronizaste com o remoto `origin`. Antes de fazeres
+o `push` dos teus _commits_ locais, tentas integrar possíveis _commits_ em
+`origin/master` no teu `master` local (fazendo por exemplo, `git pull`), mas
+obténs a seguinte mensagem de erro:
+
+```text
+Unpacking objects: 100% (6/6), done.
+From https://gitlab.com/ulht/projeto.git
+   17858a5..1601016  master     -> origin/master
+Auto-merging MyGame/BigBadBoss.cs
+CONFLICT (content): Merge conflict in MyGame/BigBadBoss.cs
+Automatic merge failed; fix conflicts and then commit the result.
+```
+
+Explica qual é o problema e como o podes resolver.
+
+## Soluções
+
+### Solução 1
+
+O problema é que existe um _merge conflit_ entre o _branch_ 'origin' e o _branch_ 'master', ou seja, existem alterações na mesma linha nos diferentes _branches_.
+
+Para solucionar este problema é necessário resolver primeiro o conflito e só depois executar o _commit_.
+
+*Por [Daniela Gameiro](https://github.com/DanielaGameiro)*


### PR DESCRIPTION
Tinha o código a ultrapassar a coluna 80, por isso cortei as linhas e o nome dos branches não estavam correctamente sinalizados e agora já estão. 